### PR TITLE
2.0.4

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
 package-lock=false
 tag-version-prefix="v"
-message="chore(release): %s :tada:"
+message="chore(release): :tada: %s"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## <small>2.0.4 (2024-07-01)</small>
+
+- docs: :memo: generate docs ([e628da0](https://github.com/nodecfdi/rfc/commit/e628da0))
+- docs: :memo: update link with target documentation in nodecfdi portal library ([c3f9ca5](https://github.com/nodecfdi/rfc/commit/c3f9ca5))
+- chore: :arrow_up: update dependencies ([6a0f217](https://github.com/nodecfdi/rfc/commit/6a0f217))
+- chore: :arrow_up: update dependencies ([554cdfa](https://github.com/nodecfdi/rfc/commit/554cdfa))
+- chore: :construction: set template for message commit release ([1d525d6](https://github.com/nodecfdi/rfc/commit/1d525d6))
+- chore(deps): :arrow_up: update dependencies ([0580d8a](https://github.com/nodecfdi/rfc/commit/0580d8a))
+- test: :recycle: prefer not sepair number ([fa87bbb](https://github.com/nodecfdi/rfc/commit/fa87bbb))
+
 ## [2.0.3](https://github.com/nodecfdi/rfc/compare/v2.0.2...v2.0.3) (2024-04-27)
 
 ### Performance Improvements

--- a/README.md
+++ b/README.md
@@ -27,29 +27,9 @@ Esta librería permite trabajar con esta clave desde el aplicativo de Node o Bro
 
 Librería inspirada por la versión para php <https://github.com/phpcfdi/rfc>
 
-## Instalación
-
-NPM
-
-```bash
-npm i @nodecfdi/rfc --save
-```
-
-YARN
-
-```bash
-yarn add @nodecfdi/rfc
-```
-
-PNPM
-
-```bash
-pnpm add @nodecfdi/rfc
-```
-
 ## Documentación
 
-La documentación está disponible en el sitio web [NodeCfdi](https://nodecfdi.com)
+La documentación está disponible en el sitio web [NodeCfdi](https://nodecfdi.com/librarys/rfc/getting-started/)
 
 ## Soporte
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nodecfdi/rfc",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Librería para trabajar con RFC (Mexicano)",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -41,10 +41,11 @@
     "release": "pnpm run build && pnpm changeset publish"
   },
   "devDependencies": {
-    "@changesets/cli": "^2.27.5",
+    "@changesets/cli": "^2.27.7",
     "@commitlint/cli": "^18.6.1",
     "@commitlint/config-conventional": "^18.6.3",
-    "@nodecfdi/eslint-config": "^1.7.0",
+    "@jsprismarine/typedoc-material-theme": "^1.0.4",
+    "@nodecfdi/eslint-config": "^1.7.1",
     "@nodecfdi/prettier-config": "^1.1.1",
     "@nodecfdi/tsconfig": "^1.5.0",
     "@types/luxon": "^3.4.2",
@@ -59,9 +60,8 @@
     "luxon": "^3.4.4",
     "prettier": "^3.3.2",
     "tsup": "^8.1.0",
-    "typedoc": "^0.25.13",
-    "typedoc-material-theme": "^1.0.2",
-    "typescript": "^5.4.5",
+    "typedoc": "^0.26.3",
+    "typescript": "^5.5.3",
     "vitest": "^1.6.0"
   },
   "peerDependencies": {
@@ -89,7 +89,7 @@
     "homoclave"
   ],
   "engines": {
-    "node": "^21 || ^20 || ^19 || ^18 || ^16"
+    "node": ">=18 <=22 || ^16"
   },
   "browserslist": [
     "defaults",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@nodecfdi/prettier-config": "^1.1.1",
     "@nodecfdi/tsconfig": "^1.5.0",
     "@types/luxon": "^3.4.2",
-    "@types/node": "^20.14.6",
+    "@types/node": "^20.14.9",
     "@vitest/coverage-istanbul": "^1.6.0",
     "conventional-changelog-cli": "^5.0.0",
     "del-cli": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -41,28 +41,28 @@
     "release": "pnpm run build && pnpm changeset publish"
   },
   "devDependencies": {
-    "@changesets/cli": "^2.27.1",
+    "@changesets/cli": "^2.27.5",
     "@commitlint/cli": "^18.6.1",
     "@commitlint/config-conventional": "^18.6.3",
-    "@nodecfdi/eslint-config": "^1.6.5",
+    "@nodecfdi/eslint-config": "^1.7.0",
     "@nodecfdi/prettier-config": "^1.1.1",
     "@nodecfdi/tsconfig": "^1.5.0",
     "@types/luxon": "^3.4.2",
-    "@types/node": "^20.12.7",
-    "@vitest/coverage-istanbul": "^1.5.2",
-    "conventional-changelog-cli": "^4.1.0",
+    "@types/node": "^20.14.6",
+    "@vitest/coverage-istanbul": "^1.6.0",
+    "conventional-changelog-cli": "^5.0.0",
     "del-cli": "^5.1.0",
     "eslint": "^8.57.0",
     "eslint-define-config": "^2.1.0",
     "husky": "^9.0.11",
     "is-in-ci": "^0.1.0",
     "luxon": "^3.4.4",
-    "prettier": "^3.2.5",
-    "tsup": "^8.0.2",
+    "prettier": "^3.3.2",
+    "tsup": "^8.1.0",
     "typedoc": "^0.25.13",
     "typedoc-material-theme": "^1.0.2",
     "typescript": "^5.4.5",
-    "vitest": "^1.5.2"
+    "vitest": "^1.6.0"
   },
   "peerDependencies": {
     "@types/luxon": "3.4.2",
@@ -95,5 +95,6 @@
     "defaults",
     "not IE 11"
   ],
-  "prettier": "@nodecfdi/prettier-config"
+  "prettier": "@nodecfdi/prettier-config",
+  "packageManager": "pnpm@9.4.0"
 }

--- a/tests/unit/rfc.spec.ts
+++ b/tests/unit/rfc.spec.ts
@@ -14,7 +14,7 @@ describe('rfc', () => {
     expect(rfc.isFisica()).toBeTruthy();
     expect(rfc.calculateChecksum()).toBe('A');
     expect(rfc.doesCheckSumMatch()).toBeTruthy();
-    expect(rfc.calculateSerial()).toBe(40_270_344_269_627);
+    expect(rfc.calculateSerial()).toBe(40270344269627);
   });
 
   test('create rfc moral', () => {
@@ -29,7 +29,7 @@ describe('rfc', () => {
     expect(rfc.isFisica()).toBeFalsy();
     expect(rfc.calculateChecksum()).toBe('A');
     expect(rfc.doesCheckSumMatch()).toBeTruthy();
-    expect(rfc.calculateSerial()).toBe(1_348_025_748_541);
+    expect(rfc.calculateSerial()).toBe(1348025748541);
   });
 
   test('create with foreign', () => {
@@ -68,13 +68,13 @@ describe('rfc', () => {
   });
 
   test('serial number', () => {
-    const rfc = Rfc.fromSerial(1_348_025_748_541);
+    const rfc = Rfc.fromSerial(1348025748541);
 
     // Current serial is undefined.
-    expect(rfc.calculateSerial()).toBe(1_348_025_748_541);
+    expect(rfc.calculateSerial()).toBe(1348025748541);
     expect(rfc.getRfc()).toBe('DIM8701081LA');
     // Current serial is defined.
-    expect(rfc.calculateSerial()).toBe(1_348_025_748_541);
+    expect(rfc.calculateSerial()).toBe(1348025748541);
   });
 
   test('create bad digit', () => {

--- a/tests/unit/rfc_int_converter.spec.ts
+++ b/tests/unit/rfc_int_converter.spec.ts
@@ -32,8 +32,8 @@ describe('rfc int converter', () => {
   });
 
   test.each([
-    [40_270_344_269_627, 'COSC8001137NA'],
-    [1_348_025_748_541, 'DIM8701081LA'],
+    [40270344269627, 'COSC8001137NA'],
+    [1348025748541, 'DIM8701081LA'],
   ])('known values %s - %s', (inputSerial: number, inputRfc: string) => {
     expect(converter.intToString(inputSerial)).toBe(inputRfc);
     expect(converter.stringToInt(inputRfc)).toBe(inputSerial);

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,5 +1,5 @@
 {
-  "plugin": ["typedoc-material-theme"],
+  "plugin": ["@jsprismarine/typedoc-material-theme"],
   "themeColor": "#badc69",
   "entryPoints": ["./index.ts", "./src/errors.ts"],
   "out": "./docs"


### PR DESCRIPTION
- docs: :memo: generate docs ([e628da0](https://github.com/nodecfdi/rfc/commit/e628da0))
- docs: :memo: update link with target documentation in nodecfdi portal library ([c3f9ca5](https://github.com/nodecfdi/rfc/commit/c3f9ca5))
- chore: :arrow_up: update dependencies ([6a0f217](https://github.com/nodecfdi/rfc/commit/6a0f217))
- chore: :arrow_up: update dependencies ([554cdfa](https://github.com/nodecfdi/rfc/commit/554cdfa))
- chore: :construction: set template for message commit release ([1d525d6](https://github.com/nodecfdi/rfc/commit/1d525d6))
- chore(deps): :arrow_up: update dependencies ([0580d8a](https://github.com/nodecfdi/rfc/commit/0580d8a))
- test: :recycle: prefer not sepair number ([fa87bbb](https://github.com/nodecfdi/rfc/commit/fa87bbb))